### PR TITLE
Add Google Analytics 4 tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,13 @@ author:
       icon: "fas fa-fw fa-envelope"
       url: "mailto:joshnroy@gmail.com"
 
+# Analytics
+analytics:
+  provider: "google-gtag"
+  google:
+    tracking_id: "G-FSLWBL641C"  # GA4 Measurement ID for joshnroy.github.io
+    anonymize_ip: false  # Set to true for enhanced privacy (optional)
+
 # Site Navigation
 data:
   navigation:


### PR DESCRIPTION
## Summary
- Add GA4 analytics configuration to track site visitors
- Configure measurement ID G-FSLWBL641C for joshnroy.github.io
- Enable comprehensive visitor analytics and cross-platform tracking capabilities