### PR TITLE
Remove annotated bibliography link from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ I graduated my Master's in Computer Science at Brown University, supervised by [
 
 My goal is to research, develop, and create embodied Artificial Intelligence/Machine Learning algorithms and systems. My interests include (but are not limited to) **Reinforcement Learning (RL)**, **Planning/Reasoning**, and **Generative/World Modeling**, with applications to real-world domains such as **Robotics**, **Finance**, and **Healthcare**.
 
-I've just started writing about my thoughts. Check out my [blog](/blog/) and [annotated bibliography](/papers/).
+I've just started writing about my thoughts. Check out my [blog](/blog/).
 
 ## Publications
 


### PR DESCRIPTION
## Summary
Removing the annotated bibliography link from the homepage as requested.

## Change
- Removed link to `/papers/` from homepage navigation on line 17 of `index.md`

The annotated bibliography section still exists and is accessible directly at `/papers/`, but is no longer linked from the main page.