### PR TITLE
Harden Pages deploy: persist .nojekyll, bump checkout to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby 💎
         uses: ruby/setup-ruby@v1
         with:
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y imagemagick
           export JEKYLL_ENV=production
           bundle exec jekyll build
+          touch _site/.nojekyll # tell GitHub Pages to serve the prebuilt site as-is (no re-run of Jekyll)
       - name: Deploy 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
Follow-up hardening for the al-folio GitHub Actions deploy (`.github/workflows/deploy.yml`).

## Changes
- **Persist `.nojekyll`**: add `touch _site/.nojekyll` to the build step. The deploy action recreates the `gh-pages` branch on every run, so the `.nojekyll` I added manually would be dropped on the next deploy — after which GitHub would re-run Jekyll on the already-built output. Generating it during the build makes it durable.
- **Bump `actions/checkout` v4 → v5**: silences the runner warning that Node 20 actions are deprecated (forced to Node 24 starting 2026-06-16).

## Why
The site now serves from the `gh-pages` branch (Pages source already switched). `.nojekyll` tells GitHub Pages to serve the prebuilt static files as-is instead of running its stock Jekyll builder (which lacks the al-folio gems and would fail). This keeps that guarantee across future deploys.

No content changes; CI/deploy only.