### PR TITLE
Align homepage layout with tomsilver.github.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,13 +84,13 @@ al_folio:
 
 navbar_fixed: true
 footer_fixed: true
-search_enabled: true
-socials_in_search: true
-posts_in_search: true
-bib_search: true
+search_enabled: false
+socials_in_search: false
+posts_in_search: false
+bib_search: false
 
 # Dimensions
-max_width: 930px
+max_width: 800px
 
 # -----------------------------------------------------------------------------
 # Open Graph & Schema.org
@@ -454,10 +454,10 @@ enable_masonry: true # enables automatic project cards arrangement
 enable_math: true # enables math typesetting (uses MathJax)
 enable_tooltips: false # enables automatic tooltip links generated for each section titles on pages and posts
 enable_darkmode: true # enables switching between light/dark modes
-enable_navbar_social: false # enables displaying social links in the navbar on the about page
+enable_navbar_social: true # enables displaying social links in the navbar on the about page
 enable_project_categories: true # enables categorization of projects into multiple categories
 enable_medium_zoom: true # enables image zoom feature (as on medium.com)
-enable_progressbar: true # enables a horizontal progress bar linked to the vertical scroll position
+enable_progressbar: false # enables a horizontal progress bar linked to the vertical scroll position
 enable_video_embedding: false # enables video embedding for bibtex entries. If false, the button opens the video link in a new window.
 
 # -----------------------------------------------------------------------------

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -10,7 +10,6 @@ profile:
   image_circular: false # crops the image to make it circular
   more_info: >
     <p>New York City</p>
-    <p><a href="mailto:joshnroy@gmail.com">joshnroy@gmail.com</a></p>
 
 selected_papers: true # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
@@ -24,6 +23,8 @@ latest_posts:
   enabled: false
 ---
 
+<b>Contact</b>: [joshnroy@gmail.com](mailto:joshnroy@gmail.com)
+
 I will be starting a PhD in Robotics/AI at [Princeton](https://robotics.princeton.edu/) in Fall 2026, advised by [Tom Silver](https://tomsilver.github.io/). My research interests include abstraction, safety, and continual learning for reinforcement learning, world modeling, and planning for embodied agents — including but not limited to robots.
 
 I am currently a founding engineer at a [full-stack AI](https://www.ycombinator.com/rfs#full-stack-ai) startup called [Bridger](https://www.bridgergp.com), working on LLM, agentic, and machine-learning-enabled automation within professional services including Tax and Accounting.
@@ -34,7 +35,7 @@ I graduated with my M.S. and B.S. with honors in Computer Science at Brown Unive
 
 Check out my [blog on Medium](https://medium.com/@thosehippos).
 
-## Awards
+## awards
 
 - **Two Sigma Internal AI/LLM Hackathon — Best Project**, 2023
 - [**National Science Foundation Graduate Research Fellowship (NSF GRFP)**](https://www.nsf.gov/funding/opportunities/grfp-nsf-graduate-research-fellowship-program) — Honorable Mention, 2020 (wrote about Uncertainty Quantification)


### PR DESCRIPTION
Follow-up to the al-folio migration ([#25](https://github.com/joshnroy/joshnroy.github.io/pull/25)), which was modeled on [tomsilver.github.io](https://tomsilver.github.io/). I compared the two live sites side by side (both are al-folio with the same `profile float-right + bio` structure) and aligned the remaining layout differences, which are all config/content-level:

## Changes

**`_config.yml`**
- `enable_navbar_social: true` — social icons (CV, email, Scholar, LinkedIn, GitHub, X, RSS) now show at the top-left of the navbar on the homepage, as on Tom's site.
- `max_width: 930px → 800px` — same content column width as Tom's site.
- `search_enabled: false` (and the related `*_in_search` flags) — Tom's navbar has no search; this keeps the navbar minimal.
- `enable_progressbar: false` — Tom's site has no scroll progress bar.

**`_pages/about.md`**
- Added a **Contact**: joshnroy@gmail.com line as the first line of the bio, matching the placement on Tom's homepage; the under-photo block now holds only "New York City" (the email previously lived there, which would have duplicated it).
- Lowercased the `## Awards` heading to `## awards` so it matches the theme-generated lowercase "news" and "selected publications" headings.

## Not changed (verified equivalent)
- The profile photo already sits top-right with the bio wrapping around it, same as Tom's (`.profile.float-right` is the first element of the article on both sites).
- Section order already matches the same pattern: bio + body sections, then news, then publications, then footer social icons with a contact note.
- The large "CV" glyph in the footer icon row is the academicons `ai-cv` icon rendering as designed, not a bug.

## Verification
`bundle exec jekyll build` succeeds; served `_site/` locally and confirmed in a browser: navbar social icons present, 800px column, Contact line first, "New York City" under the photo, lowercase headings, no search icon or progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)