### PR TITLE
Unify blog link behavior, remove CV icon from social rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ Everything a human edits is Markdown/YAML:
 - **Homepage / bio**: `_pages/about.md` (`layout: about`, `permalink: /`). Body holds the bio and the **Awards** section. Frontmatter controls the profile photo (`profile.image`), the under-photo `more_info`, and the toggles for selected papers, social icons, and the news list.
 - **Publications**: `_bibliography/papers.bib` — a single BibTeX file; jekyll-scholar renders `_pages/publications.md` automatically and the `selected={true}` entries on the homepage. Add a paper by appending a BibTeX entry. Useful fields: `abbr` (venue badge), `abstract`, `selected`, `award`/`award_name`, `arxiv`/`pdf`/`url`. Author names matching `scholar.last_name`/`first_name` in `_config.yml` are auto-bolded.
 - **News**: one Markdown file per item in `_news/` (`layout: post`, `inline: true`). They render on the homepage and `/news/`, newest first.
-- **CV**: the PDF lives at `assets/pdf/Josh_Roy_CV.pdf`. `_pages/cv.md` embeds it and offers a download link; `_data/socials.yml`'s `cv_pdf` points the sidebar icon at the same file. (The al-folio structured-CV renderer is intentionally not used.)
-- **Blog**: `_pages/blog.md` is a redirect (`redirect:` frontmatter) to https://medium.com/@thosehippos — there is no on-site blog.
-- **Social links + CV path**: `_data/socials.yml` (email, Google Scholar, LinkedIn, GitHub, X, RSS, CV PDF).
+- **CV**: the PDF lives at `assets/pdf/Josh_Roy_CV.pdf`. `_pages/cv.md` embeds it and offers a download link. The CV is reachable only via the navbar page — intentionally not in the social icon rows. (The al-folio structured-CV renderer is intentionally not used.)
+- **Blog**: `_pages/blog.html` is a bare page that instantly redirects (meta refresh 0 + JS) to https://medium.com/@thosehippos — there is no on-site blog. All blog links (navbar, bio) point at `/blog/` so they behave identically; don't link Medium directly.
+- **Social links**: `_data/socials.yml` (email, Google Scholar, LinkedIn, GitHub, X). Note: the jekyll-socials plugin renders every key present regardless of value — to hide an icon, delete its line.
 - **Site-wide settings**: `_config.yml` — identity (`first_name`/`last_name`), `url`/`baseurl` (root site, so `baseurl: ""`), `scholar` author names, `analytics.google` (GA4 `G-FSLWBL641C`), and the theme/plugin wiring. Leave the `al_folio`, `scholar`, `sass`, and `plugins` blocks alone unless you know what they do.
 - **Nav order**: each page's `nav_order` frontmatter sets navbar position (publications → cv → blog).
 

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,6 +1,5 @@
 # Social media links and usernames, displayed as icons in the order defined here.
 # See the jekyll-socials plugin docs: https://github.com/george-gca/jekyll-socials
-cv_pdf: /assets/pdf/Josh_Roy_CV.pdf # path to the CV PDF (also used by the CV page)
 email: josh.roy@princeton.edu
 scholar_userid: YV1Liz4AAAAJ # Google Scholar ID
 linkedin_username: josh-roy-037997104

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -32,7 +32,7 @@ Previously, I worked as a Machine Learning Engineer on topics ranging from large
 
 I graduated with my M.S. and B.S. with honors in Computer Science at Brown University, supervised by [George Konidaris](https://cs.brown.edu/people/gdk/), [Stefanie Tellex](https://cs.brown.edu/people/stellex/), and [James Tompkin](http://jamestompkin.com/), in May 2020.
 
-Check out my [blog on Medium](https://medium.com/@thosehippos).
+Check out my [blog on Medium](/blog/).
 
 {% comment %}
 ## awards


### PR DESCRIPTION
Two consistency cleanups:

- **All blog links now open the same way.** The bio's "blog on Medium" link previously went straight to Medium in a new tab, while the navbar "blog" item went to `/blog/` in the same tab. Both now point at `/blog/`, which instantly redirects to Medium — one consistent behavior everywhere. (The alternative — making the navbar link directly external — either writes a junk `https:/` directory into the built site or requires vendoring the theme's navbar template, so the `/blog/` funnel is the clean option.)
- **CV icon removed from the social icon rows** (navbar top-left and footer). The CV stays reachable via the `cv` navbar page next to blog. Also fixed the stale CLAUDE.md docs (blog.md → blog.html, socials list).

## Verification
Local `jekyll build`: zero `ai-cv` icons, zero direct Medium hrefs on the homepage, the bio link renders as `<a href="/blog/">blog on Medium</a>`, the `cv` nav link is intact, and no stray build artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)